### PR TITLE
Use org.apache.logging.log4j.LogManager.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ compileTestJava {
 
 
 dependencies {
+    implementation 'org.apache.logging.log4j:log4j-api:2.11.2'
+    implementation 'org.apache.logging.log4j:log4j-core:2.11.2'
     implementation 'org.slf4j:slf4j-log4j12:1.7.21'
     implementation 'org.apache.commons:commons-lang3:3.4'
     implementation 'org.apache.commons:commons-math3:3.5'

--- a/src/main/java/org/broadinstitute/hdf5/HDF5Library.java
+++ b/src/main/java/org/broadinstitute/hdf5/HDF5Library.java
@@ -4,8 +4,8 @@ import ncsa.hdf.hdf5lib.H5;
 import ncsa.hdf.hdf5lib.exceptions.HDF5LibraryException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.broadinstitute.gatk.nativebindings.NativeLibrary;
 
 import java.io.File;


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/gatk/issues/3763. Not sure if this is the right version to use.